### PR TITLE
feat: Support inherit_defer directive

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -84,6 +84,7 @@ module.exports = grammar({
         $.variable_assignment,
         $.unset_statement,
         $.inherit_directive,
+        $.inherit_defer_directive,
         $.include_directive,
         $.require_directive,
         $.export_statement,
@@ -157,6 +158,16 @@ module.exports = grammar({
         $.inherit_path,
       )),
     ),
+
+    inherit_defer_directive: $ => seq(
+      'inherit_defer',
+      repeat1(choice(
+        $.variable_expansion,
+        $.inline_python,
+        $.inherit_path,
+      )),
+    ),
+
     inherit_path: _ => /[^$ \r\n][^ \r\n]+/,
 
     inherit_configuration_directive: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -23,6 +23,10 @@
               },
               {
                 "type": "SYMBOL",
+                "name": "inherit_defer_directive"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "include_directive"
               },
               {
@@ -351,6 +355,35 @@
         {
           "type": "STRING",
           "value": "inherit"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_expansion"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "inline_python"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "inherit_path"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "inherit_defer_directive": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "inherit_defer"
         },
         {
           "type": "REPEAT1",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1787,6 +1787,29 @@
     }
   },
   {
+    "type": "inherit_defer_directive",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "inherit_path",
+          "named": true
+        },
+        {
+          "type": "inline_python",
+          "named": true
+        },
+        {
+          "type": "variable_expansion",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "inherit_directive",
     "named": true,
     "fields": {},
@@ -2482,6 +2505,10 @@
         },
         {
           "type": "include_directive",
+          "named": true
+        },
+        {
+          "type": "inherit_defer_directive",
           "named": true
         },
         {
@@ -3602,6 +3629,10 @@
   },
   {
     "type": "inherit",
+    "named": false
+  },
+  {
+    "type": "inherit_defer",
     "named": false
   },
   {


### PR DESCRIPTION
The `inherit_defer` is the same as the `inherit` in terms of what is allowed to follow it.

Reference:
https://git.openembedded.org/bitbake/commit/?id=5c2e840eafeba1f0f754c226b87bfb674f7bea29